### PR TITLE
Allow user-provided task factories for async methods

### DIFF
--- a/src/Microsoft.Scripting/HostBridge/BridgeManager.cs
+++ b/src/Microsoft.Scripting/HostBridge/BridgeManager.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Scripting.HostBridge
             classBridges_ = new Dictionary<Type, ClassBridge>();
         }
 
-        public ClassBridge GetBridge(Type type)
+        public ClassBridge GetBridge(Type type, TaskFactory taskFactory)
         {
             ClassBridge result;
             if (classBridges_.TryGetValue(type, out result))
@@ -37,7 +37,7 @@ namespace Microsoft.Scripting.HostBridge
             }
             else
             {
-                result = new ClassBridge(type, this);
+                result = new ClassBridge(type, this, taskFactory);
                 classBridges_.Add(type, result);
             }
 

--- a/src/Microsoft.Scripting/JavaScript/JavaScriptConverter.cs
+++ b/src/Microsoft.Scripting/JavaScript/JavaScriptConverter.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Scripting.JavaScript
             }
         }
 
-        public JavaScriptValue FromObjectViaNewBridge(object o)
+        public JavaScriptValue FromObjectViaNewBridge(object o, TaskFactory taskFactory)
         {
             var eng = GetEngine();
             if (o == null)
@@ -329,9 +329,14 @@ namespace Microsoft.Scripting.JavaScript
             }
             else
             {
-                ClassBridge cb = hostBridge_.GetBridge(t);
+                ClassBridge cb = hostBridge_.GetBridge(t, taskFactory);
                 return cb.ProjectObject(o);
             }
+        }
+
+        public JavaScriptValue FromObjectViaNewBridge(object o)
+        {
+            return FromObjectViaNewBridge(o, Task.Factory);
         }
 
         public object ToObject(JavaScriptValue val)

--- a/src/Microsoft.Scripting/JavaScript/JavaScriptEngine.cs
+++ b/src/Microsoft.Scripting/JavaScript/JavaScriptEngine.cs
@@ -770,6 +770,11 @@ return p;
             return CreateObjectFromHandle(resultHandle) as JavaScriptFunction;
         }
 
+        public JavaScriptFunction CreateFunction(JavaScriptCallableAsyncFunction hostFunction, AsyncHostFunctionKind functionMarshalingKind = AsyncHostFunctionKind.Promise)
+        {
+            return CreateFunction(hostFunction, Task.Factory, functionMarshalingKind);
+        }
+
         public JavaScriptFunction CreateFunction(JavaScriptCallableAsyncFunction hostFunction, string name, AsyncHostFunctionKind functionMarshalingKind = AsyncHostFunctionKind.Promise)
         {
             return null;

--- a/src/Microsoft.Scripting/JavaScript/JavaScriptEngine.cs
+++ b/src/Microsoft.Scripting/JavaScript/JavaScriptEngine.cs
@@ -671,8 +671,8 @@ namespace Microsoft.Scripting.JavaScript
 
             return CreateObjectFromHandle(resultHandle) as JavaScriptFunction;
         }
-
-        public JavaScriptFunction CreateFunction(JavaScriptCallableAsyncFunction hostFunction, AsyncHostFunctionKind functionMarshalingKind = AsyncHostFunctionKind.Promise)
+        
+        public JavaScriptFunction CreateFunction(JavaScriptCallableAsyncFunction hostFunction, TaskFactory taskFactory, AsyncHostFunctionKind functionMarshalingKind = AsyncHostFunctionKind.Promise)
         {
             if (hostFunction == null)
                 throw new ArgumentNullException(nameof(hostFunction));
@@ -708,7 +708,9 @@ return p;
 
                     var promise = Promise_.Construct(new[] { promiseInit });
 
-                    Task.Run(async () =>
+                    var runner = (taskFactory == Task.Factory ? (Func < Func<Task>, Task> )Task.Run : taskFactory.StartNew);
+
+                    runner(async () =>
                     {
                         JavaScriptValue resultValue = null;
                         bool succeeded = false;

--- a/src/Microsoft.Scripting/Microsoft.Scripting.csproj
+++ b/src/Microsoft.Scripting/Microsoft.Scripting.csproj
@@ -34,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Errors.cs" />


### PR DESCRIPTION
This commit refactors lots of methods and classes to allow the use of
user-provided task factories, useful for spawning async functions in
single-threaded applications or environments where
SynchronizationContext.Current = null
